### PR TITLE
Issue-1 Eliminar credenciales expuestas del repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Archivos de entorno con credenciales
+.env
+*.env
+!.env.example
+ 
+# Entorno virtual
+venv/
+env/
+.venv/
+.env/
+ 
+# Archivos de Python compilados
+__pycache__/
+*.py[cod]
+*$py.class
+ 
+# Configuración de IDEs
+.vscode/
+.idea/
+ 
+# Archivos temporales
+*.log
+*.tmp
+*.swp
+ 
+# Ignorar el directorio de compilación de MkDocs
+**/site/

--- a/docker-influx-grafana-nodered-py/.env.example
+++ b/docker-influx-grafana-nodered-py/.env.example
@@ -1,0 +1,12 @@
+# --- Configuración InfluxDB ---
+INFLUX_ORG=tu_organizacion
+INFLUX_BUCKET=tu_bucket_nodered
+INFLUX_BUCKET_PANDAS=tu_bucket_pandas
+INFLUX_URL=http://influxdb:8086
+INFLUX_USER=tu_usuario
+INFLUX_PASSWORD=tu_password_segura
+INFLUX_TOKEN=tu_token_seguro
+ 
+# --- Configuración Grafana ---
+GRAFANA_USER=tu_usuario_grafana
+GRAFANA_PASSWORD=tu_password_grafana

--- a/docker-sql/.env.example
+++ b/docker-sql/.env.example
@@ -1,0 +1,10 @@
+# --- Configuración SQL Server ---
+ACCEPT_EULA=Y
+SA_PASSWORD=TuPasswordSegura
+MSSQL_PID=Express
+ 
+# --- Configuración de la app ---
+DB_SERVER=sqlserver
+DB_NAME=criptosdb
+DB_USER=sa
+DB_PASSWORD=TuPasswordSegura


### PR DESCRIPTION
Los ficheros .env de docker-influx-grafana-nodered-py y docker-sql estaban commiteados con contraseñas en texto plano (tokens de InfluxDB, credenciales de Grafana y SQL Server). Esto supone una vulnerabilidad crítica.
Cambios realizados
Eliminados del tracking los ficheros .env con git rm --cached (se mantienen en local).
Creados ficheros .env.example como plantilla con valores genéricos para ambos directorios.
Creado .gitignore en la raíz del proyecto para ignorar todos los .env y permitir los .env.example.
Post-merge (recomendado)
Limpiar el historial con git filter-repo o BFG para eliminar las credenciales de commits anteriores.
Rotar todas las credenciales expuestas.
Todos los miembros del equipo deben re-clonar el repositorio tras la limpieza.