### PR TITLE
issue-02 Añadir .gitignore y eliminar archivos sensibles/binarios del repositorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+# ========================
+# .gitignore - Proyecto reto0-pia-g1
+# ========================
+ 
+# ---- Variables de entorno y credenciales ----
+.env
+.env.*
+!.env.example
+ 
+# ---- SQL Server: datos binarios de base de datos ----
+*.mdf
+*.ldf
+sql_data/
+ 
+# ---- Logs ----
+*.log
+*.xel
+errorlog
+errorlog.*
+ 
+# ---- Python: bytecode y cachés ----
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+*.egg
+dist/
+build/
+*.whl
+ 
+# ---- Entornos virtuales ----
+venv/
+.venv/
+env/
+ 
+# ---- Node-RED: credenciales ----
+flows_cred.json
+ 
+# ---- Docker: volúmenes y datos persistentes ----
+docker-sql/sql_data/
+ 
+# ---- IDE / Editor ----
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+ 
+# ---- Secretos y claves ----
+secrets/
+*.key
+*.pem
+machine-key


### PR DESCRIPTION
El repositorio carecía de un .gitignore en la raíz, lo que provocó que se incluyeran en el control de versiones archivos que nunca deberían estar rastreados: binarios de SQL Server (.mdf, .ldf), logs del sistema, secretos (machine-key), credenciales de Node-RED (flows_cred.json) y datos internos del SO (certificados, licencias, LSA). En total, 45 archivos problemáticos.
 
Cambios realizados
Creado .gitignore en la raíz del proyecto con reglas para:
 
Variables de entorno y credenciales (.env, flows_cred.json)
Binarios de SQL Server (*.mdf, *.ldf, sql_data/)
Logs (*.log, *.xel, errorlog*)
Python (__pycache__/, *.pyc, venv/)
Secretos y claves (secrets/, *.key, *.pem, machine-key)
IDE/Editor (.vscode/, .idea/)
Eliminados del tracking (sin borrar del disco) con git rm --cached:
 
sql_data completo (42 archivos binarios, logs y secretos)
docker-influx-grafana-nodered-py/nodered/flows_cred.json
Nota sobre el historial
Los archivos siguen presentes en commits anteriores. Se recomienda valorar una limpieza con git filter-repo si se considera necesario, teniendo en cuenta que requiere que todos los colaboradores re-clonen el repositorio.