### PR TITLE
issue-03 Eliminar credenciales hardcodeadas como fallback en el código

### DIFF
--- a/docker-sql/app/app.py
+++ b/docker-sql/app/app.py
@@ -5,20 +5,31 @@ import json
 from datetime import datetime
 import time
 import socket
-
+ 
 import os
 import subprocess
-
+import sys
+ 
 # -----------------------------
 # Funciones auxiliares
 # -----------------------------
-
+ 
+def get_required_env(var_name):
+    """Obtiene una variable de entorno obligatoria.
+    Si no está definida, termina el programa con un mensaje de error claro."""
+    value = os.getenv(var_name)
+    if value is None:
+        print(f"❌ ERROR: La variable de entorno '{var_name}' no está definida.")
+        print(f"   Defínela antes de ejecutar la aplicación (por ejemplo, en el archivo .env).")
+        sys.exit(1)
+    return value
+ 
 def obtener_criptos():
     url = "https://api.coinlore.net/api/tickers/"
     with urllib.request.urlopen(url) as response:
         data = json.loads(response.read())
         return data.get("data", [])
-
+ 
 def esperar_sqlserver(host, port, timeout=60):
     start = time.time()
     while True:
@@ -31,18 +42,18 @@ def esperar_sqlserver(host, port, timeout=60):
                 raise TimeoutError("SQL Server no respondió a tiempo")
             print("⏳ SQL Server no listo, reintentando en 2s...")
             time.sleep(2)
-
+ 
 # -----------------------------
 # Conexión y creación DB
 # -----------------------------
-
+ 
 def conectar_db():
-    server = os.getenv("DB_SERVER", "sqlserver")
-    database = os.getenv("DB_NAME", "criptosdb")
-    username = os.getenv("DB_USER", "sa")
-    password = os.getenv("DB_PASSWORD", "TuPasswordSegura123")
+    server = get_required_env("DB_SERVER")
+    database = get_required_env("DB_NAME")
+    username = get_required_env("DB_USER")
+    password = get_required_env("DB_PASSWORD")
     driver = "{ODBC Driver 18 for SQL Server}"
-
+ 
     # Conectarse a master con autocommit
     conn_master = None
     while True:
@@ -55,22 +66,22 @@ def conectar_db():
         except pyodbc.Error:
             print("⏳ Esperando a que SQL Server acepte conexiones...")
             time.sleep(2)
-
+ 
     cursor = conn_master.cursor()
     cursor.execute(f"IF DB_ID('{database}') IS NULL CREATE DATABASE {database};")
     cursor.close()
     conn_master.close()
-
+ 
     # Conectarse a la base creada
     conn = pyodbc.connect(
         f"DRIVER={driver};SERVER={server};DATABASE={database};UID={username};PWD={password};TrustServerCertificate=yes;"
     )
     return conn
-
+ 
 # -----------------------------
 # Crear tablas si no existen
 # -----------------------------
-
+ 
 def crear_tabla(conn):
     cursor = conn.cursor()
     cursor.execute("""
@@ -96,22 +107,22 @@ def crear_tabla(conn):
     """)
     conn.commit()
     cursor.close()
-
+ 
 # -----------------------------
 # Guardar datos
 # -----------------------------
-
+ 
 def guardar_datos(conn, monedas):
     cursor = conn.cursor()
     timestamp = datetime.now()
-
+ 
     for moneda in monedas:
         # Inserta en criptomonedas si no existe
         cursor.execute("""
             IF NOT EXISTS (SELECT 1 FROM criptomonedas WHERE id = ?)
             INSERT INTO criptomonedas (id, nombre, simbolo) VALUES (?, ?, ?)
         """, (moneda["id"], moneda["id"], moneda["name"], moneda["symbol"]))
-
+ 
         # Inserta precio
         cursor.execute("""
             INSERT INTO precios (crypto_id, rank, price_usd, percent_change_24h, percent_change_7d, price_btc, fecha)
@@ -125,22 +136,22 @@ def guardar_datos(conn, monedas):
             moneda["price_btc"],
             timestamp
         ))
-
+ 
     conn.commit()
     cursor.close()
     print(f"[{timestamp}] {len(monedas)} filas insertadas correctamente.")
-
+ 
 # -----------------------------
 # Programa principal
 # -----------------------------
-
+ 
 if __name__ == "__main__":
     print("⏳ Esperando que SQL Server esté listo...")
-    esperar_sqlserver(os.getenv("DB_SERVER", "sqlserver"), 1433)
-
+    esperar_sqlserver(get_required_env("DB_SERVER"), 1433)
+ 
     conn = conectar_db()
     crear_tabla(conn)
-
+ 
     while True:
         monedas = obtener_criptos()
         print("⏳ Obteniendo datos de criptomonedas...")


### PR DESCRIPTION
En app.py, las credenciales de SQL Server estaban hardcodeadas como valores por defecto en las llamadas a os.getenv(). Si las variables de entorno no se definían, la app seguía funcionando con contraseñas reales en el código fuente (TuPasswordSegura123, sa, etc.).
 
Cambios realizados
- Creada función get_required_env() que obtiene variables de entorno de forma obligatoria. Si no están definidas, el programa termina con sys.exit(1) y un mensaje de error claro.
- Reemplazadas las 5 llamadas a os.getenv() con fallback por get_required_env() (tanto en conectar_db() como en __main__).
- Añadido import sys necesario para sys.exit(1).