### PR TITLE
Issue 04 Añadir timeout a las llamadas HTTP a la API externa

### DIFF
--- a/docker-csv/app/app.py
+++ b/docker-csv/app/app.py
@@ -3,48 +3,50 @@ import json
 import csv
 import os
 from datetime import datetime
-
+ 
+HTTP_TIMEOUT = 10  # segundos
+ 
 def obtener_criptos():
     url = "https://api.coinlore.net/api/tickers/"
     try:
-        with urllib.request.urlopen(url) as response:
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as response:
             data = response.read()
             return json.loads(data)
     except Exception as e:
-        print("Error al hacer la petición:", e)
+        print(f"⚠️ Error al hacer la petición (timeout={HTTP_TIMEOUT}s):", e)
         return None
-
-
+ 
+ 
 if __name__ == "__main__":
     criptos = obtener_criptos()
     if criptos:
         monedas = criptos.get("data", [])
-
+ 
         # Columnas del CSV
         columnas_precio = ["rank", "price_usd", "percent_change_24h",
                            "percent_change_7d", "price_btc", "date", "id"]
-
+ 
         # Nombre fijo del archivo
         nombre_archivo = "/data/precio.csv"
-
+ 
         # Timestamp para la columna "date"
         timestamp_fila = datetime.now().isoformat()
-
+ 
         # Verificar si el archivo ya existe
         archivo_existe = os.path.exists(nombre_archivo)
-
+ 
         # Abrir en modo "append" para agregar al final sin borrar lo anterior
         with open(nombre_archivo, "a", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=columnas_precio)
-
+ 
             # Si el archivo es nuevo, escribir encabezados
             if not archivo_existe:
                 writer.writeheader()
-
+ 
             # Escribir las nuevas filas
             for moneda in monedas:
                 row = {k: moneda.get(k) for k in columnas_precio if k != "date"}
                 row["date"] = timestamp_fila
                 writer.writerow(row)
-
+ 
         print(f"Datos agregados correctamente a '{nombre_archivo}'")

--- a/docker-influx-grafana-nodered-py/app.py
+++ b/docker-influx-grafana-nodered-py/app.py
@@ -4,12 +4,12 @@ import os
 from datetime import datetime
 from influxdb_client import InfluxDBClient, Point, WriteOptions, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
-
+ 
 INFLUX_URL = os.environ.get("INFLUX_URL")
 TOKEN = os.environ.get("INFLUX_TOKEN")
 ORG = os.environ.get("INFLUX_ORG")
 BUCKET = os.environ.get("INFLUX_BUCKET_PANDAS")
-
+ 
 # Creamos el bucket de pandas en influx
 with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     # Creamos el bucket si no existe
@@ -24,38 +24,47 @@ with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     except InfluxDBError as e:
         print(f"[{datetime.now()}] ❌ Error al listar o crear bucket: {e}")
         raise
-
+ 
 # Cogemos los datos de la API y los pasamos a JSON
-
+ 
+HTTP_TIMEOUT = 10  # segundos
+ 
 endpoint = "https://api.coinlore.net/api/tickers"
-response = requests.get(endpoint)
-
+try:
+    response = requests.get(endpoint, timeout=HTTP_TIMEOUT)
+except requests.exceptions.Timeout:
+    print(f"[{datetime.now()}] ⚠️ Timeout al conectar con la API (>{HTTP_TIMEOUT}s). Abortando este ciclo.")
+    exit(1)
+except requests.exceptions.RequestException as e:
+    print(f"[{datetime.now()}] ⚠️ Error de conexión con la API: {e}")
+    exit(1)
+ 
 if response.status_code == 200:
     data = response.json()
 else:
     raise Exception(f"Error al obtener datos: {response.status_code}")
-
+ 
 # Pasamos el JSON a DataFrame
-
+ 
 coins = data['data']
 df = pd.DataFrame(coins)
-
+ 
 df_coins = df[['symbol','name','price_usd','rank','percent_change_24h','percent_change_7d','price_btc']].copy()
-
+ 
 df_coins = df_coins[(df_coins['symbol'] == 'BTC') | (df_coins['symbol'] == 'ETH') | (df_coins['symbol'] == 'BNB') | (df_coins['symbol'] == 'XRP') | (df_coins['symbol'] == 'USDT') | (df_coins['symbol'] == 'SOL') | (df_coins['symbol'] == 'USDC') | (df_coins['symbol'] == 'SOON') | (df_coins['symbol'] == 'STETH')]
-
+ 
 # Establecemos date y lo ponemos como indice
 df_coins['date'] = pd.to_datetime(datetime.now())
-
+ 
 df_coins = df_coins.set_index('date')
-
+ 
 # Subimos los datos a Influx
 try:
     with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
         write_api = client.write_api(write_options=WriteOptions(batch_size=1))
         try:
             for _, row in df_coins.iterrows():
-                
+               
                     p = (
                         Point("Criptomonedas")
                         .tag("symbol", row["symbol"])
@@ -70,6 +79,6 @@ try:
         except Exception as e:
             print(f"[{datetime.now()}] ❌ Error registrando {e}")
         write_api.__del__()
-        
+       
 except Exception as e:
     print(f"[{datetime.now()}] ❌ Error de conexión con InfluxDB: {e}")

--- a/docker-sql/app/app.py
+++ b/docker-sql/app/app.py
@@ -5,20 +5,26 @@ import json
 from datetime import datetime
 import time
 import socket
-
+ 
 import os
 import subprocess
-
+ 
 # -----------------------------
 # Funciones auxiliares
 # -----------------------------
-
+ 
+HTTP_TIMEOUT = 10  # segundos
+ 
 def obtener_criptos():
     url = "https://api.coinlore.net/api/tickers/"
-    with urllib.request.urlopen(url) as response:
-        data = json.loads(response.read())
-        return data.get("data", [])
-
+    try:
+        with urllib.request.urlopen(url, timeout=HTTP_TIMEOUT) as response:
+            data = json.loads(response.read())
+            return data.get("data", [])
+    except Exception as e:
+        print(f"⚠️ Error al obtener datos de la API (timeout={HTTP_TIMEOUT}s): {e}")
+        return None
+ 
 def esperar_sqlserver(host, port, timeout=60):
     start = time.time()
     while True:
@@ -31,18 +37,18 @@ def esperar_sqlserver(host, port, timeout=60):
                 raise TimeoutError("SQL Server no respondió a tiempo")
             print("⏳ SQL Server no listo, reintentando en 2s...")
             time.sleep(2)
-
+ 
 # -----------------------------
 # Conexión y creación DB
 # -----------------------------
-
+ 
 def conectar_db():
     server = os.getenv("DB_SERVER", "sqlserver")
     database = os.getenv("DB_NAME", "criptosdb")
     username = os.getenv("DB_USER", "sa")
     password = os.getenv("DB_PASSWORD", "TuPasswordSegura123")
     driver = "{ODBC Driver 18 for SQL Server}"
-
+ 
     # Conectarse a master con autocommit
     conn_master = None
     while True:
@@ -55,22 +61,22 @@ def conectar_db():
         except pyodbc.Error:
             print("⏳ Esperando a que SQL Server acepte conexiones...")
             time.sleep(2)
-
+ 
     cursor = conn_master.cursor()
     cursor.execute(f"IF DB_ID('{database}') IS NULL CREATE DATABASE {database};")
     cursor.close()
     conn_master.close()
-
+ 
     # Conectarse a la base creada
     conn = pyodbc.connect(
         f"DRIVER={driver};SERVER={server};DATABASE={database};UID={username};PWD={password};TrustServerCertificate=yes;"
     )
     return conn
-
+ 
 # -----------------------------
 # Crear tablas si no existen
 # -----------------------------
-
+ 
 def crear_tabla(conn):
     cursor = conn.cursor()
     cursor.execute("""
@@ -96,22 +102,22 @@ def crear_tabla(conn):
     """)
     conn.commit()
     cursor.close()
-
+ 
 # -----------------------------
 # Guardar datos
 # -----------------------------
-
+ 
 def guardar_datos(conn, monedas):
     cursor = conn.cursor()
     timestamp = datetime.now()
-
+ 
     for moneda in monedas:
         # Inserta en criptomonedas si no existe
         cursor.execute("""
             IF NOT EXISTS (SELECT 1 FROM criptomonedas WHERE id = ?)
             INSERT INTO criptomonedas (id, nombre, simbolo) VALUES (?, ?, ?)
         """, (moneda["id"], moneda["id"], moneda["name"], moneda["symbol"]))
-
+ 
         # Inserta precio
         cursor.execute("""
             INSERT INTO precios (crypto_id, rank, price_usd, percent_change_24h, percent_change_7d, price_btc, fecha)
@@ -125,27 +131,29 @@ def guardar_datos(conn, monedas):
             moneda["price_btc"],
             timestamp
         ))
-
+ 
     conn.commit()
     cursor.close()
     print(f"[{timestamp}] {len(monedas)} filas insertadas correctamente.")
-
+ 
 # -----------------------------
 # Programa principal
 # -----------------------------
-
+ 
 if __name__ == "__main__":
     print("⏳ Esperando que SQL Server esté listo...")
     esperar_sqlserver(os.getenv("DB_SERVER", "sqlserver"), 1433)
-
+ 
     conn = conectar_db()
     crear_tabla(conn)
-
+ 
     while True:
-        monedas = obtener_criptos()
         print("⏳ Obteniendo datos de criptomonedas...")
+        monedas = obtener_criptos()
         if monedas:
             guardar_datos(conn, monedas)
             print("✅ Datos guardados exitosamente.")
-            print("⏳ Esperando 3 minutos para la siguiente actualización...")
+        else:
+            print("⚠️ No se obtuvieron datos en este ciclo. Se reintentará en el siguiente.")
+        print("⏳ Esperando 3 minutos para la siguiente actualización...")
         time.sleep(180)


### PR DESCRIPTION

Los tres scripts Python del proyecto realizan peticiones HTTP a la API de CoinLore sin timeout. Si la API no responde, el proceso queda bloqueado indefinidamente, causando pérdida silenciosa de datos sin posibilidad de recuperación.
Cambios realizados
Se añadió un timeout de 10 segundos (HTTP_TIMEOUT = 10) como constante en cada script, junto con manejo de errores adecuado:
docker-csv/app/app.py: añadido timeout=HTTP_TIMEOUT a urlopen().
docker-sql/app/app.py: añadido timeout=HTTP_TIMEOUT a urlopen(), añadido try/except (no existía) y manejo de None en el bucle principal.
docker-influx-grafana-nodered-py/app.py: añadido timeout=HTTP_TIMEOUT a requests.get(), añadido try/except diferenciando Timeout de RequestException.
Comportamiento esperado
API no responde: antes el proceso quedaba bloqueado indefinidamente; ahora falla tras 10s, registra un warning y continúa o reintenta.
API responde normal: funciona exactamente igual (respuesta típica menor a 1s).