### PR TITLE
issue-09 Corregir uso incorrecto del cliente de InfluxDB

### DIFF
--- a/docker-influx-grafana-nodered-py/app.py
+++ b/docker-influx-grafana-nodered-py/app.py
@@ -4,12 +4,12 @@ import os
 from datetime import datetime
 from influxdb_client import InfluxDBClient, Point, WriteOptions, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
-
+ 
 INFLUX_URL = os.environ.get("INFLUX_URL")
 TOKEN = os.environ.get("INFLUX_TOKEN")
 ORG = os.environ.get("INFLUX_ORG")
 BUCKET = os.environ.get("INFLUX_BUCKET_PANDAS")
-
+ 
 # Creamos el bucket de pandas en influx
 with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     # Creamos el bucket si no existe
@@ -24,52 +24,52 @@ with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     except InfluxDBError as e:
         print(f"[{datetime.now()}] ❌ Error al listar o crear bucket: {e}")
         raise
-
+ 
 # Cogemos los datos de la API y los pasamos a JSON
-
+ 
 endpoint = "https://api.coinlore.net/api/tickers"
 response = requests.get(endpoint)
-
+ 
 if response.status_code == 200:
     data = response.json()
 else:
     raise Exception(f"Error al obtener datos: {response.status_code}")
-
+ 
 # Pasamos el JSON a DataFrame
-
+ 
 coins = data['data']
 df = pd.DataFrame(coins)
-
+ 
 df_coins = df[['symbol','name','price_usd','rank','percent_change_24h','percent_change_7d','price_btc']].copy()
-
+ 
 df_coins = df_coins[(df_coins['symbol'] == 'BTC') | (df_coins['symbol'] == 'ETH') | (df_coins['symbol'] == 'BNB') | (df_coins['symbol'] == 'XRP') | (df_coins['symbol'] == 'USDT') | (df_coins['symbol'] == 'SOL') | (df_coins['symbol'] == 'USDC') | (df_coins['symbol'] == 'SOON') | (df_coins['symbol'] == 'STETH')]
-
+ 
 # Establecemos date y lo ponemos como indice
 df_coins['date'] = pd.to_datetime(datetime.now())
-
+ 
 df_coins = df_coins.set_index('date')
-
+ 
 # Subimos los datos a Influx
 try:
     with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
         write_api = client.write_api(write_options=WriteOptions(batch_size=1))
         try:
             for _, row in df_coins.iterrows():
-                
-                    p = (
-                        Point("Criptomonedas")
-                        .tag("symbol", row["symbol"])
-                        .field("rank", int(row["rank"]))
-                        .field("price_usd", float(row["price_usd"]))
-                        .field("percent_change_24h", float(row["percent_change_24h"]))
-                        .field("percent_change_7d", float(row["percent_change_7d"]))
-                        .field("price_btc", float(row["price_btc"]))
-                    )
-                    write_api.write(bucket=BUCKET, org=ORG, record=p)
+                p = (
+                    Point("Criptomonedas")
+                    .tag("symbol", row["symbol"])
+                    .field("rank", int(row["rank"]))
+                    .field("price_usd", float(row["price_usd"]))
+                    .field("percent_change_24h", float(row["percent_change_24h"]))
+                    .field("percent_change_7d", float(row["percent_change_7d"]))
+                    .field("price_btc", float(row["price_btc"]))
+                )
+                write_api.write(bucket=BUCKET, org=ORG, record=p)
             print(f"[{datetime.now()}] ✅ Registrados correctamente")
         except Exception as e:
             print(f"[{datetime.now()}] ❌ Error registrando {e}")
-        write_api.__del__()
-        
+        finally:
+            write_api.close()
+ 
 except Exception as e:
     print(f"[{datetime.now()}] ❌ Error de conexión con InfluxDB: {e}")


### PR DESCRIPTION
En docker-influx-grafana-nodered-py/app.py, el write_api de InfluxDB se cerraba llamando directamente al destructor write_api.del(), lo cual es una mala práctica. Esto podía causar pérdida silenciosa de datos (el buffer no se vacía correctamente) y además no se ejecutaba en caso de excepción al estar fuera del bloque try/except.
Cambios realizados
Sustituido write_api.del() por write_api.close(), que es el método público diseñado para cerrar el write_api y hace flush del buffer antes de cerrar.
Movida la llamada a un bloque finally, garantizando que se ejecute siempre, tanto si la escritura tiene éxito como si falla.
Corregida indentación inconsistente del bucle for.