### PR TITLE
Issue-10 Sustituir print() por logging estructurado en todos los scripts

### DIFF
--- a/docker-csv/app/app.py
+++ b/docker-csv/app/app.py
@@ -2,8 +2,17 @@ import urllib.request
 import json
 import csv
 import os
+import logging
 from datetime import datetime
-
+ 
+# Configuración de logging estructurado
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+logger = logging.getLogger(__name__)
+ 
 def obtener_criptos():
     url = "https://api.coinlore.net/api/tickers/"
     try:
@@ -11,40 +20,42 @@ def obtener_criptos():
             data = response.read()
             return json.loads(data)
     except Exception as e:
-        print("Error al hacer la petición:", e)
+        logger.error("Error al hacer la petición: %s", e)
         return None
-
-
+ 
+ 
 if __name__ == "__main__":
     criptos = obtener_criptos()
     if criptos:
         monedas = criptos.get("data", [])
-
+ 
         # Columnas del CSV
         columnas_precio = ["rank", "price_usd", "percent_change_24h",
                            "percent_change_7d", "price_btc", "date", "id"]
-
+ 
         # Nombre fijo del archivo
         nombre_archivo = "/data/precio.csv"
-
+ 
         # Timestamp para la columna "date"
         timestamp_fila = datetime.now().isoformat()
-
+ 
         # Verificar si el archivo ya existe
         archivo_existe = os.path.exists(nombre_archivo)
-
+ 
         # Abrir en modo "append" para agregar al final sin borrar lo anterior
         with open(nombre_archivo, "a", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=columnas_precio)
-
+ 
             # Si el archivo es nuevo, escribir encabezados
             if not archivo_existe:
                 writer.writeheader()
-
+ 
             # Escribir las nuevas filas
             for moneda in monedas:
                 row = {k: moneda.get(k) for k in columnas_precio if k != "date"}
                 row["date"] = timestamp_fila
                 writer.writerow(row)
-
-        print(f"Datos agregados correctamente a '{nombre_archivo}'")
+ 
+        logger.info("Datos agregados correctamente a '%s'", nombre_archivo)
+    else:
+        logger.warning("No se pudieron obtener datos de criptomonedas")

--- a/docker-influx-grafana-nodered-py/app.py
+++ b/docker-influx-grafana-nodered-py/app.py
@@ -1,15 +1,24 @@
 import pandas as pd
 import requests
 import os
+import logging
 from datetime import datetime
 from influxdb_client import InfluxDBClient, Point, WriteOptions, BucketsApi
 from influxdb_client.client.exceptions import InfluxDBError
-
+ 
+# Configuración de logging estructurado
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+logger = logging.getLogger(__name__)
+ 
 INFLUX_URL = os.environ.get("INFLUX_URL")
 TOKEN = os.environ.get("INFLUX_TOKEN")
 ORG = os.environ.get("INFLUX_ORG")
 BUCKET = os.environ.get("INFLUX_BUCKET_PANDAS")
-
+ 
 # Creamos el bucket de pandas en influx
 with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     # Creamos el bucket si no existe
@@ -17,45 +26,45 @@ with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
     try:
         bucket_list = buckets_api.find_buckets().buckets
         if not any(b.name == BUCKET for b in bucket_list):
-            print(f"[{datetime.now()}] ⚡ Bucket '{BUCKET}' no existe, creando...")
+            logger.info("Bucket '%s' no existe, creando...", BUCKET)
             buckets_api.create_bucket(bucket_name=BUCKET, org=ORG)
         else:
-            print(f"[{datetime.now()}] ✅ Bucket '{BUCKET}' ya existe")
+            logger.info("Bucket '%s' ya existe", BUCKET)
     except InfluxDBError as e:
-        print(f"[{datetime.now()}] ❌ Error al listar o crear bucket: {e}")
+        logger.error("Error al listar o crear bucket: %s", e)
         raise
-
+ 
 # Cogemos los datos de la API y los pasamos a JSON
-
+ 
 endpoint = "https://api.coinlore.net/api/tickers"
 response = requests.get(endpoint)
-
+ 
 if response.status_code == 200:
     data = response.json()
 else:
     raise Exception(f"Error al obtener datos: {response.status_code}")
-
+ 
 # Pasamos el JSON a DataFrame
-
+ 
 coins = data['data']
 df = pd.DataFrame(coins)
-
+ 
 df_coins = df[['symbol','name','price_usd','rank','percent_change_24h','percent_change_7d','price_btc']].copy()
-
+ 
 df_coins = df_coins[(df_coins['symbol'] == 'BTC') | (df_coins['symbol'] == 'ETH') | (df_coins['symbol'] == 'BNB') | (df_coins['symbol'] == 'XRP') | (df_coins['symbol'] == 'USDT') | (df_coins['symbol'] == 'SOL') | (df_coins['symbol'] == 'USDC') | (df_coins['symbol'] == 'SOON') | (df_coins['symbol'] == 'STETH')]
-
+ 
 # Establecemos date y lo ponemos como indice
 df_coins['date'] = pd.to_datetime(datetime.now())
-
+ 
 df_coins = df_coins.set_index('date')
-
+ 
 # Subimos los datos a Influx
 try:
     with InfluxDBClient(url=INFLUX_URL, token=TOKEN, org=ORG) as client:
         write_api = client.write_api(write_options=WriteOptions(batch_size=1))
         try:
             for _, row in df_coins.iterrows():
-                
+               
                     p = (
                         Point("Criptomonedas")
                         .tag("symbol", row["symbol"])
@@ -66,10 +75,10 @@ try:
                         .field("price_btc", float(row["price_btc"]))
                     )
                     write_api.write(bucket=BUCKET, org=ORG, record=p)
-            print(f"[{datetime.now()}] ✅ Registrados correctamente")
+            logger.info("Registrados correctamente")
         except Exception as e:
-            print(f"[{datetime.now()}] ❌ Error registrando {e}")
+            logger.error("Error registrando: %s", e)
         write_api.__del__()
-        
+       
 except Exception as e:
-    print(f"[{datetime.now()}] ❌ Error de conexión con InfluxDB: {e}")
+    logger.error("Error de conexión con InfluxDB: %s", e)

--- a/docker-sql/app/app.py
+++ b/docker-sql/app/app.py
@@ -2,47 +2,59 @@ import os
 import pyodbc
 import urllib.request
 import json
+import logging
 from datetime import datetime
 import time
 import socket
-
+ 
 import os
 import subprocess
-
+ 
+# -----------------------------
+# Configuración de logging estructurado
+# -----------------------------
+ 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+logger = logging.getLogger(__name__)
+ 
 # -----------------------------
 # Funciones auxiliares
 # -----------------------------
-
+ 
 def obtener_criptos():
     url = "https://api.coinlore.net/api/tickers/"
     with urllib.request.urlopen(url) as response:
         data = json.loads(response.read())
         return data.get("data", [])
-
+ 
 def esperar_sqlserver(host, port, timeout=60):
     start = time.time()
     while True:
         try:
             with socket.create_connection((host, port), timeout=2):
-                print("✅ SQL Server está disponible.")
+                logger.info("SQL Server está disponible.")
                 return
         except OSError:
             if time.time() - start > timeout:
                 raise TimeoutError("SQL Server no respondió a tiempo")
-            print("⏳ SQL Server no listo, reintentando en 2s...")
+            logger.warning("SQL Server no listo, reintentando en 2s...")
             time.sleep(2)
-
+ 
 # -----------------------------
 # Conexión y creación DB
 # -----------------------------
-
+ 
 def conectar_db():
     server = os.getenv("DB_SERVER", "sqlserver")
     database = os.getenv("DB_NAME", "criptosdb")
     username = os.getenv("DB_USER", "sa")
     password = os.getenv("DB_PASSWORD", "TuPasswordSegura123")
     driver = "{ODBC Driver 18 for SQL Server}"
-
+ 
     # Conectarse a master con autocommit
     conn_master = None
     while True:
@@ -53,24 +65,24 @@ def conectar_db():
             )
             break
         except pyodbc.Error:
-            print("⏳ Esperando a que SQL Server acepte conexiones...")
+            logger.warning("Esperando a que SQL Server acepte conexiones...")
             time.sleep(2)
-
+ 
     cursor = conn_master.cursor()
     cursor.execute(f"IF DB_ID('{database}') IS NULL CREATE DATABASE {database};")
     cursor.close()
     conn_master.close()
-
+ 
     # Conectarse a la base creada
     conn = pyodbc.connect(
         f"DRIVER={driver};SERVER={server};DATABASE={database};UID={username};PWD={password};TrustServerCertificate=yes;"
     )
     return conn
-
+ 
 # -----------------------------
 # Crear tablas si no existen
 # -----------------------------
-
+ 
 def crear_tabla(conn):
     cursor = conn.cursor()
     cursor.execute("""
@@ -96,22 +108,22 @@ def crear_tabla(conn):
     """)
     conn.commit()
     cursor.close()
-
+ 
 # -----------------------------
 # Guardar datos
 # -----------------------------
-
+ 
 def guardar_datos(conn, monedas):
     cursor = conn.cursor()
     timestamp = datetime.now()
-
+ 
     for moneda in monedas:
         # Inserta en criptomonedas si no existe
         cursor.execute("""
             IF NOT EXISTS (SELECT 1 FROM criptomonedas WHERE id = ?)
             INSERT INTO criptomonedas (id, nombre, simbolo) VALUES (?, ?, ?)
         """, (moneda["id"], moneda["id"], moneda["name"], moneda["symbol"]))
-
+ 
         # Inserta precio
         cursor.execute("""
             INSERT INTO precios (crypto_id, rank, price_usd, percent_change_24h, percent_change_7d, price_btc, fecha)
@@ -125,27 +137,29 @@ def guardar_datos(conn, monedas):
             moneda["price_btc"],
             timestamp
         ))
-
+ 
     conn.commit()
     cursor.close()
-    print(f"[{timestamp}] {len(monedas)} filas insertadas correctamente.")
-
+    logger.info("%d filas insertadas correctamente.", len(monedas))
+ 
 # -----------------------------
 # Programa principal
 # -----------------------------
-
+ 
 if __name__ == "__main__":
-    print("⏳ Esperando que SQL Server esté listo...")
+    logger.info("Esperando que SQL Server esté listo...")
     esperar_sqlserver(os.getenv("DB_SERVER", "sqlserver"), 1433)
-
+ 
     conn = conectar_db()
     crear_tabla(conn)
-
+ 
     while True:
         monedas = obtener_criptos()
-        print("⏳ Obteniendo datos de criptomonedas...")
+        logger.info("Obteniendo datos de criptomonedas...")
         if monedas:
             guardar_datos(conn, monedas)
-            print("✅ Datos guardados exitosamente.")
-            print("⏳ Esperando 3 minutos para la siguiente actualización...")
+            logger.info("Datos guardados exitosamente.")
+            logger.info("Esperando 3 minutos para la siguiente actualización...")
+        else:
+            logger.warning("No se obtuvieron datos de criptomonedas.")
         time.sleep(180)


### PR DESCRIPTION
Los tres scripts Python del proyecto usaban exclusivamente print() para mostrar mensajes de estado. Esto impedía distinguir entre niveles de severidad, filtrar logs en producción y tener timestamps consistentes.
Cambios realizados
Se sustituyeron todos los print() por el módulo estándar logging de Python en los tres scripts (docker-csv/app/app.py, app.py y docker-influx-grafana-nodered-py/app.py), con una configuración uniforme: nivel INFO, formato con timestamp automático y nivel de severidad en cada línea.
Cada mensaje se clasificó por severidad: INFO para operaciones normales, WARNING para situaciones anómalas no críticas y ERROR para fallos. Se eliminaron los emojis y los timestamps manuales (datetime.now()), ya que logging los gestiona de forma estandarizada. Se utilizó el estilo de formato %s en lugar de f-strings, siguiendo la recomendación oficial de Python.
Los logs ahora son filtrables con herramientas como grep por nivel de severidad.